### PR TITLE
fix Use SKU insteaad of Product ID option

### DIFF
--- a/src/app/code/community/Sr/Gdrt/Block/Init.php
+++ b/src/app/code/community/Sr/Gdrt/Block/Init.php
@@ -13,7 +13,7 @@ class Sr_Gdrt_Block_Init extends Mage_Core_Block_Template
     {
         $prefix = $suffix = '';
 
-        $value = $this->getConfig('use_product_id') ? $product->getId() : $product->getSku();
+        $value = $this->getConfig('use_sku') ? $product->getSku() : $product->getId();
 
         $isConfiguarable = in_array($product->getTypeId(), array(
                 Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE,


### PR DESCRIPTION
This commit fixes the incorrect option name and allows the extension's "Use SKU insteaad of Product ID" option function.